### PR TITLE
Remove unused totalSize variable

### DIFF
--- a/src/js/radialTree.js
+++ b/src/js/radialTree.js
@@ -207,7 +207,6 @@ function RadialTree(element, option){
             t: 10
         };
         var colors = d3.scaleOrdinal(d3.schemeCategory20b);
-        var totalSize = 0;
         var vis = d3.select("#chart")
             .append("svg:svg")
             .attr("width", width)
@@ -255,7 +254,6 @@ function RadialTree(element, option){
 
             d3.select("#d3_container")
             .on("mouseleave", mouseleave);
-            totalSize = path.datum().value;
         };
 
         function OpenTheUrl(d) {


### PR DESCRIPTION
`totalSize` is assigned a value but never used anywhere.
Also checked `wayback-machine-chrome` project and it wasn't used there
either. Thus, I suggest to remove it.