### PR TITLE
Reduce extra mapping function in timemap.js

### DIFF
--- a/src/js/processing/timemap.js
+++ b/src/js/processing/timemap.js
@@ -43,7 +43,6 @@ export function extractYearsFromGroupedTimeMap(data) {
   }
 
   return Object.keys(data)
-    .map(y => Number.parseInt(y))
     .sort();
 }
 
@@ -84,7 +83,7 @@ export function processTimeMap(data, {groupBy, dedupBy, orderBy} = {}) {
       result[fields.getValueByName(row, groupBy)] = oneGroup;
       return result;
     }, {});
-
+    
   // if someday we would get bad performance here
   // we could make insertion with sorthing above
   return _(res)

--- a/tests/main/processing/timemap.spec.js
+++ b/tests/main/processing/timemap.spec.js
@@ -40,7 +40,7 @@ describe('time map processing', () => {
           ['2005', 'org,iskme)/about-us', 'iskme.org/about-us'],
           ['2005', 'org,iskme)/about-us/about-iskme', 'iskme.org/about-us/about-iskme'],
         ],
-      })).to.be.deep.equal([2003, 2004, 2005]);
+      })).to.be.deep.equal(["2003", "2004", "2005"]);
     });
   });
 

--- a/tests/main/processing/timemap.spec.js
+++ b/tests/main/processing/timemap.spec.js
@@ -40,7 +40,7 @@ describe('time map processing', () => {
           ['2005', 'org,iskme)/about-us', 'iskme.org/about-us'],
           ['2005', 'org,iskme)/about-us/about-iskme', 'iskme.org/about-us/about-iskme'],
         ],
-      })).to.be.deep.equal(["2003", "2004", "2005"]);
+      })).to.be.deep.equal(['2003', '2004', '2005']);
     });
   });
 


### PR DESCRIPTION
@vbanos I have reduced extra function calling from timemap.js which is used to extract the years. The time of rendering reduced to some extent.